### PR TITLE
Load commands via reflection

### DIFF
--- a/Server/Assets/Scripts/CommandAttribute.cs
+++ b/Server/Assets/Scripts/CommandAttribute.cs
@@ -1,0 +1,36 @@
+using System;
+
+[AttributeUsage(AttributeTargets.Class)]
+public class CommandAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandAttribute"/> class.
+    /// </summary>
+    /// <param name="name">The name of the command.</param>
+    /// <remarks>Defaults to the command having an empty description.</remarks>
+    public CommandAttribute(string name)
+        : this(name, string.Empty)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandAttribute"/> class.
+    /// </summary>
+    /// <param name="name">The name of the command.</param>
+    /// <param name="description">A brief description of the command.</param>
+    public CommandAttribute(string name, string description)
+    {
+        this.Name = name;
+        this.Description = description;
+    }
+
+    /// <summary>
+    /// Gets the description of this command.
+    /// </summary>
+    public string Description { get; }
+
+    /// <summary>
+    /// Gets the name of this command.
+    /// </summary>
+    public string Name { get; }
+}

--- a/Server/Assets/Scripts/CommandAttribute.cs.meta
+++ b/Server/Assets/Scripts/CommandAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1a031a836986f4a4dba322c1379d80a0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Server/Assets/Scripts/CommandManager.cs
+++ b/Server/Assets/Scripts/CommandManager.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+public class CommandManager
+{
+    private Dictionary<string, Command> commands = new Dictionary<string, Command>();
+
+    /// <summary>
+    /// Gets a dictionary which contains the commands, such that the key represents the command name, and the value
+    /// represents the description.
+    /// </summary>
+    public Dictionary<string, string> GetCommandsWithDescriptions()
+    {
+        var result = new Dictionary<string, string>();
+
+        foreach (Command command in this.commands.Values)
+        {
+            var type = command.GetType();
+            var attribute = type.GetCustomAttribute<CommandAttribute>();
+            if (attribute is null)
+            {
+                continue;
+            }
+
+            result.Add(attribute.Name, attribute.Description);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Registers a command to be recognised by this manager.
+    /// </summary>
+    /// <param name="command">The command instance to register.</param>
+    public void RegisterCommand(Command command)
+    {
+        if (!(command.GetType().GetCustomAttribute<CommandAttribute>() is CommandAttribute attribute))
+        {
+            throw new ArgumentException(
+                $"{nameof(command)} does not have {nameof(CommandAttribute)}",
+                nameof(command));
+        }
+
+        this.commands.Add(attribute.Name, command);
+    }
+
+    /// <summary>
+    /// Registers all <see cref="Command"/> types found in the current assembly.
+    /// </summary>
+    public void RegisterAssemblyCommands()
+    {
+        var baseType = typeof(Command);
+        var assembly = Assembly.GetAssembly(baseType);
+        var allTypes = assembly.GetTypes();
+        var commandTypes = allTypes.Where(t => t.IsSubclassOf(baseType));
+
+        foreach (var type in commandTypes)
+        {
+            var instance = Activator.CreateInstance(type) as Command;
+            this.RegisterCommand(instance);
+        }
+    }
+
+    /// <summary>
+    /// Attempts to call <see cref="Command.Run(string[])"/> on the command whose name matches <paramref name="name"/>.
+    /// </summary>
+    /// <param name="name">The command name.</param>
+    /// <param name="args">The command arguments.</param>
+    /// <returns><see langword="true"/> if the execution was successful, <see langword="false"/> otherwise.</returns>
+    public bool TryRunCommand(string name, string[] args)
+    {
+        if (!commands.TryGetValue(name, out Command command))
+        {
+            // no such command
+            return false;
+        }
+
+        command.Run(args);
+        return true;
+    }
+}

--- a/Server/Assets/Scripts/CommandManager.cs.meta
+++ b/Server/Assets/Scripts/CommandManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f8db738c1ca30fa498053ce64f16c1b3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Server/Assets/Scripts/Commands/Broadcast.cs
+++ b/Server/Assets/Scripts/Commands/Broadcast.cs
@@ -1,3 +1,4 @@
+[Command("broadcast")]
 public class Broadcast : Command
 {
     public override void Run(string[] args) 

--- a/Server/Assets/Scripts/Commands/Exit.cs
+++ b/Server/Assets/Scripts/Commands/Exit.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 
+[Command("exit")]
 public class Exit : Command
 {
     public override void Run(string[] args) 

--- a/Server/Assets/Scripts/Commands/Help.cs
+++ b/Server/Assets/Scripts/Commands/Help.cs
@@ -1,7 +1,26 @@
-﻿public class Help : Command
+﻿using System.Collections.Generic;
+
+[Command("help", "Lists available commands")]
+public class Help : Command
 {
-    public override void Run(string[] args) 
+    public override void Run(string[] args)
     {
-        Console.Log("Commands: broadcast, list, kick, status, start, stop, restart, exit");
+        // list all registered commands by the manager
+        // while also printing the command description - if there is one
+
+        var commandManager = this.Console.CommandManager;
+        var commands = commandManager.GetCommandsWithDescriptions();
+
+        foreach (var pair in commands)
+        {
+            var output = pair.Key;
+
+            if (!string.IsNullOrWhiteSpace(pair.Value))
+            {
+                output += $"- {pair.Value}";
+            }
+
+            this.Console.Log(output);
+        }
     }
 }

--- a/Server/Assets/Scripts/Commands/Kick.cs
+++ b/Server/Assets/Scripts/Commands/Kick.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 
+[Command("kick")]
 public class Kick : Command
 {
     public override void Run(string[] args) 

--- a/Server/Assets/Scripts/Commands/List.cs
+++ b/Server/Assets/Scripts/Commands/List.cs
@@ -1,3 +1,4 @@
+[Command("list")]
 public class List : Command
 {
     public override void Run(string[] args) 

--- a/Server/Assets/Scripts/Commands/Restart.cs
+++ b/Server/Assets/Scripts/Commands/Restart.cs
@@ -1,3 +1,4 @@
+[Command("restart")]
 public class Restart : Command
 {
     public override void Run(string[] args)

--- a/Server/Assets/Scripts/Commands/Start.cs
+++ b/Server/Assets/Scripts/Commands/Start.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 
+[Command("start")]
 public class Start : Command
 {
     public override void Run(string[] args)

--- a/Server/Assets/Scripts/Commands/Status.cs
+++ b/Server/Assets/Scripts/Commands/Status.cs
@@ -1,3 +1,4 @@
+[Command("status")]
 public class Status : Command
 {
     public override void Run(string[] args)

--- a/Server/Assets/Scripts/Commands/Stop.cs
+++ b/Server/Assets/Scripts/Commands/Stop.cs
@@ -1,3 +1,4 @@
+[Command("stop")]
 public class Stop : Command
 {
     public override void Run(string[] args)


### PR DESCRIPTION
Satisfies issue #10 

- Commands are attributed with a `CommandAttribute` attribute, to specify their name and description.
- `CommandManager` class registers all types in the assembly which are of type `Command` and have `CommandAttribute` attribute
- `Console` class now calls on `CommandManager` to register these commands, and also to execute them